### PR TITLE
Fixed deleting menus and empty canteens

### DIFF
--- a/data/storage.txt
+++ b/data/storage.txt
@@ -16,6 +16,8 @@ TechnoEdge<>western town<>not bad but very ex//2.5//2021-01-03
 TechnoEdge<>western town<>chicken chop<>5.5
 TechnoEdge<>western town<>fish and chip<>4.5
 TechnoEdge<>western town<>carbonara<>5.5
+TechnoEdge<>western town<>Testing Menu<>5.0
+TechnoEdge<>western town<>Testing Menu 2<>4.0
 TechnoEdge<>mala
 TechnoEdge<>mala<>Food is delicious but always very long queue//4.0//2021-01-04
 TechnoEdge<>mala<>very long queue but very nice//3.4//2021-01-24

--- a/data/storage.txt
+++ b/data/storage.txt
@@ -16,8 +16,6 @@ TechnoEdge<>western town<>not bad but very ex//2.5//2021-01-03
 TechnoEdge<>western town<>chicken chop<>5.5
 TechnoEdge<>western town<>fish and chip<>4.5
 TechnoEdge<>western town<>carbonara<>5.5
-TechnoEdge<>western town<>Testing Menu<>5.0
-TechnoEdge<>western town<>Testing Menu 2<>4.0
 TechnoEdge<>mala
 TechnoEdge<>mala<>Food is delicious but always very long queue//4.0//2021-01-04
 TechnoEdge<>mala<>very long queue but very nice//3.4//2021-01-24

--- a/src/main/java/command/AddMenuCommand.java
+++ b/src/main/java/command/AddMenuCommand.java
@@ -32,6 +32,7 @@ public class AddMenuCommand extends Command {
     public void getMenu(ArrayList<Canteen> canteens, Ui ui) throws NumberFormatException, IOException, DukeExceptions {
         String menuName;
         double menuPrice;
+        Integer currentStoreIndex;
 
         nusFoodReviews.setCanteenIndex();
         int currentCanteenIndex = nusFoodReviews.getCanteenIndex();
@@ -40,11 +41,14 @@ public class AddMenuCommand extends Command {
             return;
         }
         ui.showDisplayStores(canteens.get(currentCanteenIndex));
+
         ui.chooseStore();
         String line = ui.readCommand();
         if (line.equals("cancel")) {
             ui.menuNotAdded();
             return;
+        } else {
+            currentStoreIndex = Integer.parseInt(line) - 1;
         }
 
         ui.enterMenuName();
@@ -55,6 +59,7 @@ public class AddMenuCommand extends Command {
         } else {
             menuName = line;
         }
+
         ui.enterMenuPrice();
         line = ui.readCommand();
         if (line.equals("cancel")) {
@@ -64,9 +69,7 @@ public class AddMenuCommand extends Command {
             menuPrice = Double.parseDouble(line);
         }
 
-        Integer currentStoreIndex = Integer.parseInt(line) - 1;
         Canteen canteen = canteens.get(currentCanteenIndex);
-
         Menu menu = new Menu(menuName,menuPrice);
         canteen.getStore(currentStoreIndex).addMenu(menu);
         ui.menuAdded();

--- a/src/main/java/command/DeleteMenuCommand.java
+++ b/src/main/java/command/DeleteMenuCommand.java
@@ -31,8 +31,13 @@ public class DeleteMenuCommand extends Command {
             ui.showMenuNotDeleted();
             return;
         }
+        Canteen canteen = canteens.get(currentCanteenIndex);
+        if (canteen.getNumStores() < 1) {
+            ui.showEmptyCanteen();
+            return;
+        }
         ui.showDisplayStores(canteens.get(currentCanteenIndex));
-        ui.chooseStore();
+        ui.chooseDeleteStore();
 
         String line = ui.readCommand();
         if (line.equals("cancel")) {
@@ -41,10 +46,14 @@ public class DeleteMenuCommand extends Command {
         }
         int currentStoreIndex = Integer.parseInt(line) - 1;
         ArrayList<Menu> menus = canteens.get(currentCanteenIndex).getStore(currentStoreIndex).getMenus();
+        if (menus.size() < 1) {
+            ui.showNoMenuToDelete();
+            return;
+        }
         ui.showDisplayMenu(canteens.get(currentCanteenIndex).getStore(currentStoreIndex).getStoreName(),
                 menus);
-        ui.chooseMenu();
 
+        ui.chooseMenu();
         line = ui.readCommand();
         if (line.equals("cancel")) {
             ui.showMenuNotDeleted();

--- a/src/main/java/nusfoodreviews/NusFoodReviews.java
+++ b/src/main/java/nusfoodreviews/NusFoodReviews.java
@@ -140,6 +140,10 @@ public class NusFoodReviews {
     public void setStoreIndex() throws DukeExceptions {
         Canteen canteen = canteens.get(canteenIndex);
         ui.showDisplaySelectStores(canteen);
+        if (canteen.getNumStores() < 1) {
+            resetCanteenStoreIndex();
+            return;
+        }
         String line = ui.readCommand();
         if (line.equals("exit")) {
             ui.showGoodbye();

--- a/src/main/java/parser/Parser.java
+++ b/src/main/java/parser/Parser.java
@@ -118,6 +118,9 @@ public class Parser {
         case "9":
             newCommand = new ExitCommand();
             break;
+        case "login":
+            newCommand = new LoginCommand(nusFoodReviews);
+            break;
         default:
             throw new DukeExceptions("Please enter a valid index!");
         }

--- a/src/main/java/ui/Ui.java
+++ b/src/main/java/ui/Ui.java
@@ -95,6 +95,11 @@ public class Ui {
         System.out.println(LINESPACING);
     }
 
+    public void chooseDeleteStore() {
+        System.out.println("Please select store to delete menu from.");
+        System.out.println(LINESPACING);
+    }
+
     public void enterMenuName() {
         System.out.println("Please enter name of menu.");
         System.out.println(LINESPACING);
@@ -155,6 +160,12 @@ public class Ui {
         System.out.println(Ui.LINESPACING);
     }
 
+    public void showEmptyCanteen() {
+        System.out.println(LINESPACING);
+        System.out.println("There are no stores in this canteen!");
+        System.out.println(LINESPACING);
+    }
+
     public void showDisplayMenu(String storeName, ArrayList<Menu> menus) {
         System.out.println(LINESPACING);
         int count = 1;
@@ -166,6 +177,12 @@ public class Ui {
         for (Menu menuItem: menus) {
             System.out.println(count++ + ")" + menuItem.toString());
         }
+    }
+
+    public void showNoMenuToDelete() {
+        System.out.println(LINESPACING);
+        System.out.println("There is no menus to delete!");
+        System.out.println(LINESPACING);
     }
 
     public void showDisplaySelectCanteens(ArrayList<Canteen> canteens, String action) {


### PR DESCRIPTION
Fixed #123
Fixed #124 
Fixed #116 
Fixed #117 
Fixed #119 
Fixed #127 

These issues include:
1) When the canteen is empty, and I select it as a user, it still requests for a store to be selected. However, there is no stores to select thus resulting in errors in issues 116,117,119.
2) When deleting menus as an admin, issues arise when there are no stores as well. The program still prompts for selecting a store despite there being no stores. 